### PR TITLE
Use local internet identity for localhost

### DIFF
--- a/science-grants-blockchain/src/frontend/contexts/AuthContext.tsx
+++ b/science-grants-blockchain/src/frontend/contexts/AuthContext.tsx
@@ -45,10 +45,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const login = async () => {
     if (!authClient) return
 
+    // Check if we're running on localhost
+    const isLocalhost = window.location.hostname === 'localhost' || 
+                       window.location.hostname === '127.0.0.1' ||
+                       window.location.hostname.includes('localhost');
+
     await authClient.login({
-      identityProvider: process.env.NODE_ENV === 'production' 
-        ? 'https://identity.ic0.app'
-        : `http://localhost:8000?canisterId=${process.env.INTERNET_IDENTITY_CANISTER_ID}`,
+      identityProvider: isLocalhost
+        ? `http://localhost:8000?canisterId=${process.env.INTERNET_IDENTITY_CANISTER_ID}`
+        : 'https://identity.ic0.app',
       onSuccess: () => {
         setIsAuthenticated(true)
         const identity = authClient.getIdentity()


### PR DESCRIPTION
Use `window.location.hostname` to determine Internet Identity provider for local development.

The previous check relied on `NODE_ENV === 'production'`, which was insufficient for local `dfx start` environments, leading to the use of `identity.ic0.app` instead of the local Internet Identity. This change ensures the correct local identity provider is used when running on localhost.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bcf35e8-7c20-4258-a2f9-77afe54da6bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6bcf35e8-7c20-4258-a2f9-77afe54da6bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>